### PR TITLE
Adding Shear Capacity Utilisation (SCU) as derived quantity.

### DIFF
--- a/lightquakevisualizer/lightQuakeVisualizer.py
+++ b/lightquakevisualizer/lightQuakeVisualizer.py
@@ -87,9 +87,11 @@ class seissolxdmfExtended(seissolxdmf.seissolxdmf):
             return rake
         if data_name == "SCU" and "SCU" not in super().ReadAvailableDataFields():
             Td0 = super().ReadData("Td0", idt)
+            Ts0 = super().ReadData("Ts0", idt)
+            T0 = np.sqrt(Ts0**2 + Td0**2) 
             Pn0 = super().ReadData("Pn0", idt)
             Mus = super().ReadData("Mud", 0)
-            return np.abs(Td0)/(np.multiply(np.abs(Pn0),Mus))
+            return np.abs(T0)/(np.multiply(np.abs(Pn0),Mus))
         else:
             return super().ReadData(data_name, idt)
 

--- a/lightquakevisualizer/lightQuakeVisualizer.py
+++ b/lightquakevisualizer/lightQuakeVisualizer.py
@@ -91,7 +91,7 @@ class seissolxdmfExtended(seissolxdmf.seissolxdmf):
             T0 = np.sqrt(Ts0**2 + Td0**2) 
             Pn0 = super().ReadData("Pn0", idt)
             Mus = super().ReadData("Mud", 0)
-            return np.abs(T0)/(np.multiply(np.abs(Pn0),Mus))
+            return T0/(np.multiply(np.abs(Pn0),Mus))
         else:
             return super().ReadData(data_name, idt)
 

--- a/lightquakevisualizer/lightQuakeVisualizer.py
+++ b/lightquakevisualizer/lightQuakeVisualizer.py
@@ -85,6 +85,11 @@ class seissolxdmfExtended(seissolxdmf.seissolxdmf):
                 rake[rake < 0] += 360
             # print(np.nanmin(rake), np.nanmax(rake))
             return rake
+        if data_name == "SCU" and "SCU" not in super().ReadAvailableDataFields():
+            Td0 = super().ReadData("Td0", idt)
+            Pn0 = super().ReadData("Pn0", idt)
+            Mus = super().ReadData("Mud", 0)
+            return np.abs(Td0)/(np.multiply(np.abs(Pn0),Mus))
         else:
             return super().ReadData(data_name, idt)
 


### PR DESCRIPTION
Adding Shear Capacity Utilisation (SCU) to derived data fields to keep track of shear failure during the dynamic rupture.
SCU is used to quantify risk of shear failure $SCU = \frac{Td0}{Pn0*Mus}$, where SCU is between 0 (no risk) and 1 (rock is at shear failure).

Peak or static friction Mus is derived from the Mud SeisSol data field at t=0.
