### PR TITLE
custom time annotations/ output_prefix_path/bounding_box_filter/white_colormaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ light_quake_visualizer --help
 Plot the volume output file at time 10s, variable u with a pvcc (saved from ParaView):
 
 ```
-light_quake_visualizer output_tpv5_ref/tpv5_sym.xdmf --var u --time 10.0 --cmap broc --view output_tpv5_ref/tpv5.pvcc  --scalar_bar "0.9 0.1" --color_range "-0.5 0.5" --zoom 1.0 --lighting 0.6 0.4 0.6
+light_quake_visualizer output_tpv5_ref/tpv5_sym.xdmf --var u --time 10.0 --cmap broc --view output_tpv5_ref/tpv5.pvcc  --scalar_bar "0.9 0.1" --color_range "-0.5 0.5" --zoom 1.0 --lighting 0.6 0.4 0.6  --annotate_text "black 0.1 0.9 {time:.1f}"
 ```
 
 ## Plotting several datasets
@@ -49,7 +49,7 @@ light_quake_visualizer  output_tpv5_new_format/tpv5_sym-wavefield-2.hdf --var u 
 ## Support for tandem fault output
 
 ```
-light_quake_visualizer --time "i::5" --var slip-rate --cmap turbo output/fault.pvd --view xz --log_scale 0 --scalar_bar "0.1 0.3" --annotate_text "black 0.1 0.9 {t}" --zoom 1.5 --color_range "1e-7 1e0"
+light_quake_visualizer --time "i::5" --var slip-rate --cmap turbo output/fault.pvd --view xz --log_scale 0 --scalar_bar "0.1 0.3" --annotate_text "black 0.1 0.9 {long_time}" --zoom 1.5 --color_range "1e-7 1e0"
 ```
 
 ## Generate vector graphic color bar image

--- a/lightquakevisualizer/lightQuakeVisualizer.py
+++ b/lightquakevisualizer/lightQuakeVisualizer.py
@@ -12,6 +12,7 @@ import importlib
 import h5py
 from typing import List
 from importlib.metadata import version
+import warnings
 
 pv.global_theme.nan_color = "white"
 
@@ -525,6 +526,16 @@ def validate_parameter_count(
         )
 
 
+def check_deprecated_arguments(args):
+    if args.annotate_time:
+        warnings.warn(
+            "'--annotate_time' is deprecated and will be removed in future versions. "
+            "Please use e.g. '--annotate_text black xr yr {time:.1f}s' for equivalent "
+            "output.",
+            DeprecationWarning,
+        )
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Visualize SeisSol output using pyvista"
@@ -710,6 +721,7 @@ def main():
     parser.add_argument("--zoom", metavar="zoom", help="Camera zoom", type=float)
 
     args = parser.parse_args()
+    check_deprecated_arguments(args)
 
     if not os.path.exists("output") and not args.interactive:
         os.makedirs("output")

--- a/lightquakevisualizer/lightQuakeVisualizer.py
+++ b/lightquakevisualizer/lightQuakeVisualizer.py
@@ -217,51 +217,60 @@ def get_cmap(cmap_name: str, cmap_lib: str) -> object:
         raise ValueError(f"unkown cmap_lib {cmap_lib}")
 
 
-def get_cmaps_objects(cmap_names: list) -> list:
+def get_cmaps_objects(cmap_names: list, color_ranges: list) -> list:
     """
     Get a list of colormap objects from a list of colormap names.
 
     Args:
-    cmap_names (list): A list of colormap names.
-    if a colormap is a know colormap with prepended 0
-    then the first color is changed to white
+        cmap_names (list): List of colormap names. If a name ends with '0',
+                           it indicates a special case for white insertion.
+        color_ranges (list): List of dicts with 'clim' key, each a [vmin, vmax] pair.
 
     Returns:
-    list: A list of colormap objects.
+        list: A list of colormap objects.
 
     Raises:
-    ValueError: If a colormap name is unknown.
+        ValueError: If a colormap name is unknown.
     """
     cmaps_objects = []
     available_cmaps = get_available_cmaps()
-    for cmap_name in cmap_names:
-        if cmap_name[-1] == "0":
-            change_to_white_first = True
-            cmap_name_no0 = cmap_name[0:-1]
+
+    def insert_white(cmap, position="first", num_colors=256):
+        white = np.array([1, 1, 1, 1])
+        base_colors = cmap(np.linspace(0, 1, num_colors - 1))
+        if position == "first":
+            colors = np.vstack((white, base_colors))
+        elif position == "last":
+            colors = np.vstack((base_colors, white))
         else:
-            change_to_white_first = False
-            cmap_name_no0 = cmap_name
+            raise ValueError("Invalid position for white insertion")
+        return mcolors.ListedColormap(colors, N=num_colors)
+
+    for cmap_name, crange in zip(cmap_names, color_ranges):
+        vmin, vmax = crange["clim"]
+        use_white = cmap_name.endswith("0")
+        cmap_base_name = cmap_name[:-1] if use_white else cmap_name
+
+        white_pos = None
+        if use_white:
+            if vmax <= 0:
+                white_pos = "last"
+            elif vmin >= 0:
+                white_pos = "first"
+            # else: leave white_pos = None (don't insert white)
         found = False
-        for cmaplib in available_cmaps.keys():
-            if cmap_name_no0 in available_cmaps[cmaplib]:
+        for cmaplib, names in available_cmaps.items():
+            if cmap_base_name in names:
                 found = True
-                # print(f"{cmap_name_no0} found in {cmaplib}")
-                cmap = get_cmap(cmap_name_no0, cmaplib)
-                if change_to_white_first:
-                    num_colors = 256
-                    # Create a new colormap that starts with white
-                    white = np.array([1, 1, 1, 1])
-                    new_colors = np.vstack(
-                        (white, cmap(np.linspace(0, 1, num_colors - 1)))
-                    )
-                    # Create a new colormap object
-                    cmap = mcolors.ListedColormap(
-                        new_colors, name=cmap_name, N=num_colors
-                    )
+                cmap = get_cmap(cmap_base_name, cmaplib)
+                if white_pos:
+                    cmap = insert_white(cmap, position=white_pos)
                 cmaps_objects.append(cmap)
                 break
+
         if not found:
-            raise ValueError(f"unkown cmap: {cmap_name_no0}")
+            raise ValueError(f"Unknown colormap: {cmap_base_name}")
+
     return cmaps_objects
 
 
@@ -821,7 +830,7 @@ def main():
         color_ranges = gen_color_range(args.color_ranges)
     dic_window_size = {"window_size": args.window_size}
 
-    cmaps = get_cmaps_objects(cmap_names)
+    cmaps = get_cmaps_objects(cmap_names, color_ranges)
 
     def get_snapshot_fname(args, fname, itime, time_value):
         if args.output_prefix_path:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lightquakevisualizer"
-version = "0.3.4"
+version = "0.3.5"
 authors = [
     {name = "Thomas Ulrich"},
 ]


### PR DESCRIPTION
- add custom time annotations e.g.
`--annotate_text "black 0.1 0.1 {time:.3f}s {long_time}"`
- change output_prefix to output_prefix_path with possibility of output to something else as output.
- add bounding_box_filter option for spatially filtering a mesh.
- Make sure that if e.g. viridis0 is used while stating color ranges < 0, we can still plot colormaps with white background color on fault.